### PR TITLE
Migrate System.Windows.Interactivity to Microsoft.Xaml.Behaviors.Wpf

### DIFF
--- a/TeamMerge/Behaviors/EventToCommandBehavior.cs
+++ b/TeamMerge/Behaviors/EventToCommandBehavior.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace TeamMerge.Behaviors
 {

--- a/TeamMerge/Merge/TeamMergeView.xaml
+++ b/TeamMerge/Merge/TeamMergeView.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:ui="clr-namespace:TeamMerge.UI"
-             xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+             xmlns:i="clr-namespace:Microsoft.Xaml.Behaviors;assembly=Microsoft.Xaml.Behaviors"
              xmlns:resources="clr-namespace:TeamMerge"
              xmlns:converters="clr-namespace:TeamMerge.Converters"
              mc:Ignorable="d"

--- a/TeamMerge/Settings/Views/MergeSettingsView.xaml
+++ b/TeamMerge/Settings/Views/MergeSettingsView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
+             xmlns:i="clr-namespace:Microsoft.Xaml.Behaviors;assembly=Microsoft.Xaml.Behaviors"
              xmlns:enums="clr-namespace:TeamMerge.Settings.Enums"
              xmlns:local="clr-namespace:TeamMerge.Settings.Views"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"

--- a/TeamMerge/TeamMerge.csproj
+++ b/TeamMerge/TeamMerge.csproj
@@ -175,7 +175,6 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -207,6 +206,9 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.0.2264">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
+      <Version>1.1.19</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Migration will allow for further development using newer tools, as well as will remove dependency to Microsoft Blend-related topics (what is deprecated by MS).

Being honest I was not aware of the problem when I started diving into TeamMerge code within VS 2019 (and 2017 as well), but the Internet fortunately was, so I based on [StackOverflow question](https://stackoverflow.com/questions/8360209/how-to-add-system-windows-interactivity-to-project) and [its answer](https://stackoverflow.com/a/56240223/546730).