### PR TITLE
Add button switching target and source branches selections with each other

### DIFF
--- a/TeamMerge/Merge/TeamMergeCommonCommandsViewModel.cs
+++ b/TeamMerge/Merge/TeamMergeCommonCommandsViewModel.cs
@@ -39,6 +39,7 @@ namespace TeamMerge.Merge
             FetchChangesetsCommand = new AsyncRelayCommand(FetchChangesetsAsync, CanFetchChangesets);
             SelectWorkspaceCommand = new RelayCommand<Workspace>(SelectWorkspace);
             OpenSettingsCommand = new RelayCommand(OpenSettings);
+            SwitchTargetAndSourceBranchesCommand = new RelayCommand(SwitchTargetAndSourceBranches, CanSwitchTargetAndSourceBranches);
 
             SourcesBranches = new ObservableCollection<string>();
             TargetBranches = new ObservableCollection<string>();
@@ -53,6 +54,7 @@ namespace TeamMerge.Merge
         public IRelayCommand FetchChangesetsCommand { get; }
         public IRelayCommand SelectWorkspaceCommand { get; }
         public IRelayCommand OpenSettingsCommand { get; }
+        public IRelayCommand SwitchTargetAndSourceBranchesCommand { get; }
 
         public ObservableCollection<string> ProjectNames { get; set; }
         public ObservableCollection<string> SourcesBranches { get; set; }
@@ -113,6 +115,7 @@ namespace TeamMerge.Merge
                 RaisePropertyChanged(nameof(SelectedTargetBranch));
 
                 FetchChangesetsCommand.RaiseCanExecuteChanged();
+                SwitchTargetAndSourceBranchesCommand.RaiseCanExecuteChanged();
             }
         }
 
@@ -384,5 +387,18 @@ namespace TeamMerge.Merge
                 _selectedChangesets.CollectionChanged -= SelectedChangesets_CollectionChanged;
             }
         }
+
+        private void SwitchTargetAndSourceBranches()
+        {
+            var previousSourceBranch = SelectedSourceBranch;
+            SelectedSourceBranch = SelectedTargetBranch;
+            SelectedTargetBranch = previousSourceBranch;
+        }
+
+        private bool CanSwitchTargetAndSourceBranches() =>
+            // If selected source branch is null, this command will be effectively "use target branch as source".
+            // Other way round - having target branch not selected while having source branch selected is useless,
+            // as after switching source will be empty and changing it to anything will clear target branch combo anyway.
+            SelectedTargetBranch != null;
     }
 }

--- a/TeamMerge/Merge/TeamMergeView.xaml
+++ b/TeamMerge/Merge/TeamMergeView.xaml
@@ -78,6 +78,10 @@
                   SelectedItem="{Binding TeamMergeCommandsViewModel.SelectedSourceBranch, UpdateSourceTrigger=PropertyChanged}"
                   Margin="0 0 0 10"/>
 
+        <Button Command="{Binding TeamMergeCommandsViewModel.SwitchTargetAndSourceBranchesCommand}"
+                Content="{x:Static resources:Resources.SwitchTargetAndSourceBranches}"
+                Margin="0 0 0 10" FontWeight="SemiBold"/>
+
         <TextBlock Text="{x:Static resources:Resources.TargetBranch}" />
         <ComboBox ItemsSource="{Binding TeamMergeCommandsViewModel.TargetBranches}"
                   SelectedItem="{Binding TeamMergeCommandsViewModel.SelectedTargetBranch, UpdateSourceTrigger=PropertyChanged}"

--- a/TeamMerge/Resources.Designer.cs
+++ b/TeamMerge/Resources.Designer.cs
@@ -412,6 +412,15 @@ namespace TeamMerge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ↓↑.
+        /// </summary>
+        public static string SwitchTargetAndSourceBranches {
+            get {
+                return ResourceManager.GetString("SwitchTargetAndSourceBranches", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Target.
         /// </summary>
         public static string Target {

--- a/TeamMerge/Resources.resx
+++ b/TeamMerge/Resources.resx
@@ -171,6 +171,9 @@
   <data name="SourceBranch" xml:space="preserve">
     <value>Source branch</value>
   </data>
+  <data name="SwitchTargetAndSourceBranches" xml:space="preserve">
+    <value>&#x2193;&#x2191;</value>
+  </data>
   <data name="Target" xml:space="preserve">
     <value>Target</value>
   </data>


### PR DESCRIPTION
Often scenario is:
1. Merge A --> B
2. Do some work on B
3. Merge back B --> A
When opening TeamMerge in order to do step 3, it opens with previously selected branches, that is A as source and B as target. If there are lot of branches in source combobox, serching for B may be irritating if it's repeated lot of times (and usually it is), as well as searching for target A after selecting source (what clears target combobox selection).
Button added switches comboboxes selected values, that is if source was A and target was B, after clicking source will be B and target will be A.

Reviewal note:
It is not checked whether values we want to select exist in respective comboboxes, because it is assumed that if there is possibility to select source A and target B (so do merge A-->B) then there is always possibility to do other way round (that is merge B-->A). Target combobox values are gathered as before change due to PropertyChangeNotification.